### PR TITLE
moved pipe operators to global namespace

### DIFF
--- a/Giters/Giters/Consume.h
+++ b/Giters/Giters/Consume.h
@@ -7,12 +7,12 @@ namespace Giters
 	struct Consume
 	{
 	};
+}
 
-	template <typename TSeq>
-	void operator|(TSeq&& source, Consume)
+template <typename TSeq>
+void operator|(TSeq&& source, Giters::Consume)
+{
+	for (auto&& elem : source)
 	{
-		for (auto&& elem : source)
-		{
-		}
 	}
 }

--- a/Giters/Giters/FirstOrDefault.h
+++ b/Giters/Giters/FirstOrDefault.h
@@ -27,36 +27,36 @@ namespace Giters
 		return GitersImpl::FirstOrDefault_t();
 	}
 
-	template <typename TSeq>
-	auto operator|(TSeq&& source, GitersImpl::FirstOrDefault_t)
-	{
-		for (auto&& elem : source)
-		{
-			return elem;
-		}
-
-		using Elem_t = std::remove_reference_t<decltype(*std::begin(source))>;
-		return Elem_t();
-	}
-
 	template <typename TPredicate>
 	auto FirstOrDefault(TPredicate&& predicate)
 	{
 		return GitersImpl::FirstOrDefaultWhere_t<TPredicate>(std::forward<TPredicate>(predicate));
 	}
+}
 
-	template <typename TSeq, typename TPredicate>
-	auto operator|(TSeq&& source, GitersImpl::FirstOrDefaultWhere_t<TPredicate>&& predicate)
+template <typename TSeq>
+auto operator|(TSeq&& source, Giters::GitersImpl::FirstOrDefault_t)
+{
+	for (auto&& elem : source)
 	{
-		for (auto&& elem : source)
-		{
-			if (std::invoke(predicate.predicate, elem))
-			{
-				return elem;
-			}
-		}
-
-		using Elem_t = std::remove_reference_t<decltype(*std::begin(source))>;
-		return Elem_t();
+		return elem;
 	}
+
+	using Elem_t = std::remove_reference_t<decltype(*std::begin(source))>;
+	return Elem_t();
+}
+
+template <typename TSeq, typename TPredicate>
+auto operator|(TSeq&& source, Giters::GitersImpl::FirstOrDefaultWhere_t<TPredicate>&& predicate)
+{
+	for (auto&& elem : source)
+	{
+		if (std::invoke(predicate.predicate, elem))
+		{
+			return elem;
+		}
+	}
+
+	using Elem_t = std::remove_reference_t<decltype(*std::begin(source))>;
+	return Elem_t();
 }

--- a/Giters/Giters/ForEach.h
+++ b/Giters/Giters/ForEach.h
@@ -23,13 +23,13 @@ namespace Giters
 	{
 		return GitersImpl::ForEach_t<TVisitor>(std::forward<TVisitor>(visitor));
 	}
+}
 
-	template <typename TSeq, typename TVisitor>
-	void operator|(TSeq&& source, GitersImpl::ForEach_t<TVisitor>&& visitor)
+template <typename TSeq, typename TVisitor>
+void operator|(TSeq&& source, Giters::GitersImpl::ForEach_t<TVisitor>&& visitor)
+{
+	for (auto&& elem : source)
 	{
-		for (auto&& elem : source)
-		{
-			std::invoke(visitor.visitor, elem);
-		}
+		std::invoke(visitor.visitor, elem);
 	}
 }

--- a/Giters/Giters/Select.h
+++ b/Giters/Giters/Select.h
@@ -60,10 +60,10 @@ namespace Giters
 	{
 		return GitersImpl::Select_t<TSelector>(std::forward<TSelector>(selector));
 	}
+}
 
-	template <typename TSeq, typename TSelector>
-	auto operator|(TSeq&& source, GitersImpl::Select_t<TSelector>&& selector)
-	{
-		return GitersImpl::SelectImpl<TSeq, TSelector>(source, std::forward<TSelector>(selector.selector));
-	}
+template <typename TSeq, typename TSelector>
+auto operator|(TSeq&& source, Giters::GitersImpl::Select_t<TSelector>&& selector)
+{
+	return Giters::GitersImpl::SelectImpl<TSeq, TSelector>(source, std::forward<TSelector>(selector.selector));
 }

--- a/Giters/Giters/ToVector.h
+++ b/Giters/Giters/ToVector.h
@@ -32,22 +32,6 @@ namespace Giters
 		return GitersImpl::ToVector_t{ initialCapacity };
 	}
 
-	template <typename TSeq>
-	auto operator|(TSeq&& source, GitersImpl::ToVector_t&& toVector)
-	{
-		using Elem_t = std::remove_reference_t<decltype(*std::begin(source))>;
-
-		std::vector<Elem_t> vector;
-		vector.reserve(toVector.initialCapacity);
-
-		for (auto&& elem : source)
-		{
-			vector.push_back(elem);
-		}
-
-		return vector;
-	}
-
 	template <typename TSelector>
 	auto ToVector(TSelector&& selector)
 	{
@@ -59,20 +43,36 @@ namespace Giters
 	{
 		return GitersImpl::ToVectorSelect_t<TSelector>(initialCapacity, std::forward<TSelector>(selector));
 	}
+}
 
-	template <typename TSeq, typename TSelector>
-	auto operator|(TSeq&& source, GitersImpl::ToVectorSelect_t<TSelector>&& selector)
+template <typename TSeq>
+auto operator|(TSeq&& source, Giters::GitersImpl::ToVector_t&& toVector)
+{
+	using Elem_t = std::remove_reference_t<decltype(*std::begin(source))>;
+
+	std::vector<Elem_t> vector;
+	vector.reserve(toVector.initialCapacity);
+
+	for (auto&& elem : source)
 	{
-		using Elem_t = std::remove_const_t<std::remove_reference_t<decltype(std::invoke(selector.selector, *std::begin(source)))>>;
-
-		std::vector<Elem_t> vector;
-		vector.reserve(selector.initialCapacity);
-
-		for (auto&& elem : source)
-		{
-			vector.push_back(std::invoke(selector.selector, elem));
-		}
-
-		return vector;
+		vector.push_back(elem);
 	}
+
+	return vector;
+}
+
+template <typename TSeq, typename TSelector>
+auto operator|(TSeq&& source, Giters::GitersImpl::ToVectorSelect_t<TSelector>&& selector)
+{
+	using Elem_t = std::remove_const_t<std::remove_reference_t<decltype(std::invoke(selector.selector, *std::begin(source)))>>;
+
+	std::vector<Elem_t> vector;
+	vector.reserve(selector.initialCapacity);
+
+	for (auto&& elem : source)
+	{
+		vector.push_back(std::invoke(selector.selector, elem));
+	}
+
+	return vector;
 }

--- a/Giters/Giters/Visit.h
+++ b/Giters/Giters/Visit.h
@@ -70,10 +70,10 @@ namespace Giters
 	{
 		return GitersImpl::Visit_t<TVisitor>(std::forward<TVisitor>(visitor));
 	}
+}
 
-	template <typename TSeq, typename TVisitor>
-	auto operator|(TSeq&& source, GitersImpl::Visit_t<TVisitor>&& visitor)
-	{
-		return GitersImpl::VisitImpl<TSeq, TVisitor>(source, std::forward<TVisitor>(visitor.visitor));
-	}
+template <typename TSeq, typename TVisitor>
+auto operator|(TSeq&& source, Giters::GitersImpl::Visit_t<TVisitor>&& visitor)
+{
+	return Giters::GitersImpl::VisitImpl<TSeq, TVisitor>(source, std::forward<TVisitor>(visitor.visitor));
 }

--- a/Giters/Giters/Where.h
+++ b/Giters/Giters/Where.h
@@ -70,10 +70,10 @@ namespace Giters
 	{
 		return GitersImpl::Where_t<TPredicate>(std::forward<TPredicate>(predicate));
 	}
+}
 
-	template <typename TSeq, typename TPredicate>
-	auto operator|(TSeq&& source, GitersImpl::Where_t<TPredicate>&& predicate)
-	{
-		return GitersImpl::WhereImpl<TSeq, TPredicate>(source, std::forward<TPredicate>(predicate.predicate));
-	}
+template <typename TSeq, typename TPredicate>
+auto operator|(TSeq&& source, Giters::GitersImpl::Where_t<TPredicate>&& predicate)
+{
+	return Giters::GitersImpl::WhereImpl<TSeq, TPredicate>(source, std::forward<TPredicate>(predicate.predicate));
 }

--- a/GitersTests.Google/FirstOrDefault.cpp
+++ b/GitersTests.Google/FirstOrDefault.cpp
@@ -6,7 +6,7 @@
 #include <xstring>
 #include "../Giters/Giters/FirstOrDefault.h"
 
-using namespace Giters;
+using Giters::FirstOrDefault;
 
 struct Widget
 {

--- a/GitersTests.Google/NonNull.cpp
+++ b/GitersTests.Google/NonNull.cpp
@@ -4,7 +4,9 @@
 #include <vector>
 #include "../Giters/Giters.h"
 
-using namespace Giters;
+using Giters::NonNull;
+using Giters::Select;
+using Giters::ToVector;
 
 class NonNullTest : public ::testing::Test {
 protected:

--- a/GitersTests.Google/Where.cpp
+++ b/GitersTests.Google/Where.cpp
@@ -4,7 +4,7 @@
 #include <vector>
 #include "../Giters/Giters/Where.h"
 
-using namespace Giters;
+using Giters::Where;
 
 class WhereTest : public ::testing::Test {
 protected:


### PR DESCRIPTION
`operator|()` has been moved from `Giters` to the global namespace.
This allows consumer to avoid `using namespace Giters` if they so choose.